### PR TITLE
Single resource resolver for mutations & deletions

### DIFF
--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Create.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Create.swift
@@ -88,7 +88,7 @@ public extension RelatedResourceController {
                 .flatMapThrowing { (model, related) in (try model.attached(to: related, with: keyPath), related) }
                 .flatMap { (model, related) in [related.save(on: db), model.save(on: db)]
                         .flatten(on: db.context.eventLoop)
-                    .transform(to: model) }
+                        .transform(to: model) }
                 .flatMapThrowing { try Output($0, req: req)}
         }
     }

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Delete.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Delete.swift
@@ -10,6 +10,7 @@ import Fluent
 
 public extension ResourceController {
     func delete<Model>(
+        resolver: Resolver<Model> = .byIdKeys,
         req: Request,
         db: (any Database)? = nil,
         using deleter: Deleter<Model> = .defaultDeleter(),
@@ -18,8 +19,8 @@ public extension ResourceController {
         Output.Model == Model {
 
         (db ?? req.db).tryTransaction { db in
-            try Model
-                .findByIdKey(req, database: db, queryModifier: queryModifier)
+            try resolver
+                .find(req, req.db, queryModifier)
                 .flatMap { model in
                     deleter
                         .performDelete(model, req: req, database: db)

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Delete.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Delete.swift
@@ -20,7 +20,7 @@ public extension ResourceController {
 
         (db ?? req.db).tryTransaction { db in
             try resolver
-                .find(req, req.db, queryModifier)
+                .find(req, db, queryModifier)
                 .flatMap { model in
                     deleter
                         .performDelete(model, req: req, database: db)

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Delete.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Delete.swift
@@ -124,6 +124,7 @@ public extension RelatedResourceController {
 
 public extension ResourceController {
     func delete<Model>(
+        resolver: Resolver<Model> = .byIdKeys,
         req: Request,
         db: (any Database)? = nil,
         using deleter: Deleter<Model> = .defaultDeleter(),
@@ -132,6 +133,7 @@ public extension ResourceController {
         Output.Model == Model {
 
         try await delete(
+            resolver: resolver,
             req: req,
             db: db,
             using: deleter,

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Mutate.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Mutate.swift
@@ -25,7 +25,7 @@ extension ResourceController {
         
         return (db ?? req.db).tryTransaction { db in
             try resolver
-                .find(req, req.db, queryModifier)
+                .find(req, db, queryModifier)
                 .flatMap { inputModel.mutate($0, req: req, database: db) }
                 .flatMap { model in return model.save(on: db).transform(to: model) }
                 .flatMapThrowing { try Output($0, req: req) }

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Patch.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Patch.swift
@@ -10,6 +10,7 @@ import Fluent
 
 public extension ResourceController {
     func patch<Input, Model>(
+        resolver: Resolver<Model> = .byIdKeys,
         req: Request,
         db: (any Database)? = nil,
         using: Input.Type,
@@ -20,6 +21,7 @@ public extension ResourceController {
         Input.Model == Output.Model {
         
         try mutate(
+            resolver: resolver,
             req: req,
             db: db,
             using: using,

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Patch.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Patch.swift
@@ -103,6 +103,7 @@ public extension RelatedResourceController {
 
 public extension ResourceController {
     func patch<Input, Model>(
+        resolver: Resolver<Model> = .byIdKeys,
         req: Request,
         db: (any Database)? = nil,
         using: Input.Type,
@@ -113,6 +114,7 @@ public extension ResourceController {
         Input.Model == Output.Model {
         
         try await patch(
+            resolver: resolver,
             req: req,
             db: db,
             using: Input.self,

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Read.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Read.swift
@@ -89,7 +89,7 @@ public extension ResourceController {
     
     @available(*, deprecated, renamed: "read(resolver:req:queryModifier:)", message: "Order of arguments was changed")
     func read<Model>(req: Request,
-                     resolver: Resolver<Model> = .byIdKeys,
+                     resolver: Resolver<Model>,
                      queryModifier: QueryModifier<Model> = .empty) async throws -> Output
     where
     Output.Model == Model {

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Read.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Read.swift
@@ -9,12 +9,22 @@ import Vapor
 import Fluent
 
 public extension ResourceController {
-    func read<Model>(req: Request,
-                     resolver: Resolver<Model> = .byIdKeys,
+    func read<Model>(resolver: Resolver<Model> = .byIdKeys,
+                     req: Request,
                      queryModifier: QueryModifier<Model> = .empty) throws -> EventLoopFuture<Output>
     where
     Output.Model == Model {
-        
+        try resolver
+            .find(req, req.db, queryModifier)
+            .flatMapThrowing { model in try Output(model, req: req) }
+    }
+    
+    @available(*, deprecated, renamed: "read(resolver:req:queryModifier:)", message: "Order of arguments was changed")
+    func read<Model>(req: Request,
+                     resolver: Resolver<Model>,
+                     queryModifier: QueryModifier<Model> = .empty) throws -> EventLoopFuture<Output>
+    where
+    Output.Model == Model {
         try resolver
             .find(req, req.db, queryModifier)
             .flatMapThrowing { model in try Output(model, req: req) }

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Read.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Read.swift
@@ -75,6 +75,21 @@ public extension RelatedResourceController {
 //MARK: - Concurrency
 
 public extension ResourceController {
+    @available(*, deprecated, renamed: "read(resolver:req:queryModifier:)", message: "Order of arguments was changed")
+    func read<Model>(resolver: Resolver<Model> = .byIdKeys,
+                     req: Request,
+                     queryModifier: QueryModifier<Model> = .empty) async throws -> Output
+    where
+    Output.Model == Model {
+        
+        try await read(
+            resolver: resolver,
+            req: req,
+            queryModifier: queryModifier
+        ).get()
+    }
+    
+    @available(*, deprecated, renamed: "read(resolver:req:queryModifier:)", message: "Order of arguments was changed")
     func read<Model>(req: Request,
                      resolver: Resolver<Model> = .byIdKeys,
                      queryModifier: QueryModifier<Model> = .empty) async throws -> Output
@@ -82,8 +97,8 @@ public extension ResourceController {
     Output.Model == Model {
         
         try await read(
-            req: req,
             resolver: resolver,
+            req: req,
             queryModifier: queryModifier
         ).get()
     }

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Read.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Read.swift
@@ -75,13 +75,11 @@ public extension RelatedResourceController {
 //MARK: - Concurrency
 
 public extension ResourceController {
-    @available(*, deprecated, renamed: "read(resolver:req:queryModifier:)", message: "Order of arguments was changed")
     func read<Model>(resolver: Resolver<Model> = .byIdKeys,
                      req: Request,
                      queryModifier: QueryModifier<Model> = .empty) async throws -> Output
     where
     Output.Model == Model {
-        
         try await read(
             resolver: resolver,
             req: req,

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Update.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Update.swift
@@ -11,6 +11,7 @@ import Fluent
 
 public extension ResourceController {
     func update<Input, Model>(
+        resolver: Resolver<Model> = .byIdKeys,
         req: Request,
          db: (any Database)? = nil,
         using: Input.Type,
@@ -21,6 +22,7 @@ public extension ResourceController {
         Input.Model == Output.Model {
         
         try mutate(
+            resolver: resolver,
             req: req,
             db: db,
             using: using,

--- a/Sources/VaporRestKit/Resources+CRUDs/Resource+Update.swift
+++ b/Sources/VaporRestKit/Resources+CRUDs/Resource+Update.swift
@@ -110,6 +110,7 @@ public extension RelatedResourceController {
 
 public extension ResourceController {
     func update<Input, Model>(
+        resolver: Resolver<Model> = .byIdKeys,
         req: Request,
          db: (any Database)? = nil,
         using: Input.Type,
@@ -120,6 +121,7 @@ public extension ResourceController {
         Input.Model == Output.Model {
         
             try await update(
+                resolver: resolver,
                 req: req,
                 db: db,
                 using: using,


### PR DESCRIPTION
The PR adds resolver for non-related-resource controller for mutations & deletions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the lookup path for core mutation/delete/read endpoints and adjusts public API signatures; risk is mainly behavioral differences if callers rely on the old default resolution or hit overload ambiguity.
> 
> **Overview**
> Single-resource `ResourceController` CRUDs now accept an optional `resolver: Resolver<Model> = .byIdKeys` for `delete`, `mutate` (and therefore `patch`/`update`), switching lookups from hardcoded `Model.findByIdKey` to the provided resolver.
> 
> `read` for single resources is updated to a new parameter order (`read(resolver:req:queryModifier:)`) with deprecated overloads retained for source compatibility, and async variants are updated to forward the resolver consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fd110033467e8ad4b0a4a3b09e6b91b0bb50f95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->